### PR TITLE
feature: parse chars and strings

### DIFF
--- a/server-test/Hrafnar/ParserSpec.hs
+++ b/server-test/Hrafnar/ParserSpec.hs
@@ -183,7 +183,6 @@ spec = do
         `shouldParse`
         If' (Var' "x") (Var' "y") (Var' "z")
 
-
     context "case" $ do
 
       it "simple" $

--- a/server-test/Hrafnar/ParserSpec.hs
+++ b/server-test/Hrafnar/ParserSpec.hs
@@ -153,12 +153,6 @@ spec = do
           `shouldParse`
           Lit' (String' "single quotes -> ''")
 
-        it "fail on double quotes without escaping" $
-
-          parseExpr "\"a double quote -> \"\""
-          `shouldFailWith`
-          err 20 (utok '"' <> eeof)
-
         it "parse shortest strings" $
           -- HACK: depending on `Apply` context
 

--- a/server-test/Hrafnar/ParserSpec.hs
+++ b/server-test/Hrafnar/ParserSpec.hs
@@ -17,6 +17,16 @@ spec :: Spec
 spec = do
   describe "expressions" $ do
 
+    context "literal" $
+
+      context "integer" $
+
+        it "parse an integer" $
+
+          parseExpr "42"
+          `shouldParse`
+          Lit' (Int' 42)
+
     context "if" $ do
 
       it "parse if" $

--- a/server/Hrafnar/Parser.hs
+++ b/server/Hrafnar/Parser.hs
@@ -247,13 +247,20 @@ integer f = do
   num <- lexeme Lx.decimal
   pure (f $ Int num)
 
+character :: (Lit -> a) -> Parser a
+character f = do
+  c <- lexeme $ between (char '\'') (char '\'') Lx.charLiteral
+  pure (f $ Char c)
+
 literal :: Parser Expr
 literal = do
   pos <- getSourcePos
-  At (SrcPos pos) <$> integer Lit
+  At (SrcPos pos) <$> noLocated
+  where
+    noLocated = integer Lit <|> character Lit
 
 patternLiteral :: Parser Pat'
-patternLiteral = integer PLit
+patternLiteral = integer PLit <|> character PLit
 
 -- terms
 -- | Variables include data constructors and operators.

--- a/server/Hrafnar/Parser.hs
+++ b/server/Hrafnar/Parser.hs
@@ -252,8 +252,14 @@ character f = do
   c <- lexeme $ between (char '\'') (char '\'') Lx.charLiteral
   pure (f $ Char c)
 
+-- NOTE: name "string" is used by Text.Megaparsec.Char.string
+stringLiteral :: (Lit -> a) -> Parser a
+stringLiteral f = do
+  s <- lexeme $ char '\"' *> manyTill Lx.charLiteral (char '\"')
+  pure (f $ String s)
+
 literal' :: (Lit -> a) -> Parser a
-literal' f = integer f <|> character f
+literal' f = integer f <|> character f <|> stringLiteral f
 -- HACK: don't want to repeat f.
 
 literal :: Parser Expr

--- a/server/Hrafnar/Parser.hs
+++ b/server/Hrafnar/Parser.hs
@@ -252,15 +252,17 @@ character f = do
   c <- lexeme $ between (char '\'') (char '\'') Lx.charLiteral
   pure (f $ Char c)
 
+literal' :: (Lit -> a) -> Parser a
+literal' f = integer f <|> character f
+-- HACK: don't want to repeat f.
+
 literal :: Parser Expr
 literal = do
   pos <- getSourcePos
-  At (SrcPos pos) <$> noLocated
-  where
-    noLocated = integer Lit <|> character Lit
+  At (SrcPos pos) <$> literal' Lit
 
 patternLiteral :: Parser Pat'
-patternLiteral = integer PLit <|> character PLit
+patternLiteral = literal' PLit
 
 -- terms
 -- | Variables include data constructors and operators.

--- a/server/Hrafnar/Parser.hs
+++ b/server/Hrafnar/Parser.hs
@@ -242,24 +242,23 @@ caseExpr = Lx.indentBlock scn parser
       pure $ PCon con params
 
 -- literatures
-integer :: (Lit -> a) -> Parser a
-integer f = do
+intLit :: (Lit -> a) -> Parser a
+intLit f = do
   num <- lexeme Lx.decimal
   pure (f $ Int num)
 
-character :: (Lit -> a) -> Parser a
-character f = do
+charLit :: (Lit -> a) -> Parser a
+charLit f = do
   c <- lexeme $ between (char '\'') (char '\'') Lx.charLiteral
   pure (f $ Char c)
 
--- NOTE: name "string" is used by Text.Megaparsec.Char.string
-stringLiteral :: (Lit -> a) -> Parser a
-stringLiteral f = do
+stringLit :: (Lit -> a) -> Parser a
+stringLit f = do
   s <- lexeme $ char '\"' *> manyTill Lx.charLiteral (char '\"')
   pure (f $ String s)
 
 literal' :: (Lit -> a) -> Parser a
-literal' f = integer f <|> character f <|> stringLiteral f
+literal' f = intLit f <|> charLit f <|> stringLit f
 -- HACK: don't want to repeat f.
 
 literal :: Parser Expr


### PR DESCRIPTION
close #25 

*   I've referred to <https://markkarpov.com/tutorial/megaparsec.html#char-and-string-literals>.
*   I've chosen the common notation: a character is surrounded by single-quotes, and a string is by double-quotes.
*   By using `Text.Megaparsec.Char.Lexer.charLiteral`, HML luckily or unluckily gets the ability to interpret many ways to escape special characters in a character/string literal notation.
    Those ways are the same as [Haskell's spec](https://www.haskell.org/onlinereport/haskell2010/haskellch2.html#x7-200002.6).
    Tests I added also show the spec.
*   HML can interpret `'''`, three single-quotes, as a single-quote character without escaping, while Haskell cannot. That comes from my simple implementation.
    If this spec may cause trouble, I will improve it.