### PR TITLE
Introduce heredoc

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -17,6 +17,10 @@ description:         Please see the README on GitHub at <https://github.com/real
 library:
   source-dirs: server
 
+internal-libraries:
+  hrafnar-util:
+    source-dirs: util
+
 dependencies:
 - base >= 4.7 && < 5
 
@@ -47,6 +51,7 @@ dependencies:
 - servant
 - servant-server
 - stm
+- template-haskell
 - time
 - tls
 - transformers
@@ -77,6 +82,7 @@ default-extensions:
 - MultiParamTypeClasses
 - OverloadedLabels
 - OverloadedStrings
+- QuasiQuotes
 - RankNTypes
 - RecordWildCards
 - PolyKinds
@@ -124,6 +130,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - hrafnar
+    - hrafnar-util
     - hspec
     - hspec-megaparsec
     - hspec-wai

--- a/server-test/Hrafnar/ParserSpec.hs
+++ b/server-test/Hrafnar/ParserSpec.hs
@@ -6,6 +6,7 @@ import           Hrafnar.Builtin
 import           Hrafnar.Exception
 import           Hrafnar.Parser
 import           Hrafnar.Types
+import           Hrafnar.Util
 
 import           Test.Hspec
 import           Test.Hspec.Megaparsec
@@ -33,43 +34,43 @@ spec = do
 
           it "parse a character" $
 
-            parseExpr "'c'"
+            parseExpr [rawS|'c'|]
             `shouldParse`
             Lit' (Char' 'c')
 
           it "parse a numeric character" $
 
-            parseExpr "'5'"
+            parseExpr [rawS|'5'|]
             `shouldParse`
             Lit' (Char' '5')
 
           it "parse a space" $
 
-            parseExpr "' '"
+            parseExpr [rawS|' '|]
             `shouldParse`
             Lit' (Char' ' ')
 
           it "fail on a backslash" $
 
-            parseExpr "'\\'"
+            parseExpr [rawS|'\'|]
             `shouldFailWith`
             err 3 (ueof <> etok '\'') -- This error means no ending quote mark.
 
           it "parse a single quote" $
 
-            parseExpr "'''"
+            parseExpr [rawS|'''|]
             `shouldParse`
             Lit' (Char' '\'')
 
           it "parse a double quote" $
 
-            parseExpr "'\"'"
+            parseExpr [rawS|'"'|]
             `shouldParse`
             Lit' (Char' '\"')
 
           it "fail on a zero length character" $
 
-            parseExpr "''"
+            parseExpr [rawS|''|]
             `shouldFailWith`
             err 2 (ueof <> etok '\'') -- This error means no ending quote mark.
             -- NOTE: This error depends on whether HML tries to parse a single
@@ -79,7 +80,7 @@ spec = do
 
           it "fail on a multiple length character" $
 
-            parseExpr "'ab'"
+            parseExpr [rawS|'ab'|]
             `shouldFailWith`
             err 2 (utok 'b' <> etok '\'')
 
@@ -87,37 +88,37 @@ spec = do
 
           it "parse a special character" $
 
-            parseExpr "'\\n'"
+            parseExpr [rawS|'\n'|]
             `shouldParse`
             Lit' (Char' '\n')
 
           it "parse a decimal unicode" $
 
-            parseExpr "'\\74'"
+            parseExpr [rawS|'\74'|]
             `shouldParse`
             Lit' (Char' 'J')
 
           it "parse a hexadecimal unicode" $
 
-            parseExpr "'\\x4B'"
+            parseExpr [rawS|'\x4B'|]
             `shouldParse`
             Lit' (Char' 'K')
 
           it "parse a octal unicode" $
 
-            parseExpr "'\\o114'"
+            parseExpr [rawS|'\o114'|]
             `shouldParse`
             Lit' (Char' 'L')
 
           it "parse a ascii control code abbreviation" $
 
-            parseExpr "'\\LF'"
+            parseExpr [rawS|'\LF'|]
             `shouldParse`
             Lit' (Char' '\n')
 
           it "parse a caret notation" $
 
-            parseExpr "'\\^J'"
+            parseExpr [rawS|'\^J'|]
             `shouldParse`
             Lit' (Char' '\n')
 
@@ -125,31 +126,31 @@ spec = do
 
         it "parse a string which length is 0" $
 
-          parseExpr "\"\""
+          parseExpr [rawS|""|]
           `shouldParse`
           Lit' (String' "")
 
         it "parse a string which length is 1" $
 
-          parseExpr "\"s\""
+          parseExpr [rawS|"s"|]
           `shouldParse`
           Lit' (String' "s")
 
         it "parse a string which length is 2 or over" $
 
-          parseExpr "\"st\""
+          parseExpr [rawS|"st"|]
           `shouldParse`
           Lit' (String' "st")
 
         it "parse a string including escaped characters" $
 
-          parseExpr "\" \\n \\74 \\' \\\" \\\\ \""
+          parseExpr [rawS|" \n \74 \' \" \\ "|]
           `shouldParse`
           Lit' (String' " \n J ' \" \\ ")
 
         it "parse single quotes without escaping" $
 
-          parseExpr "\"single quotes -> ''\""
+          parseExpr [rawS|"single quotes -> ''"|]
           `shouldParse`
           Lit' (String' "single quotes -> ''")
 
@@ -158,7 +159,7 @@ spec = do
 
           -- right: 2 texts: [How are you?] and [I am fine!]
           -- wrong: 1 text: [How are you?" "I am fine!]
-          parseExpr "f \"How are you?\" \"I am fine!\""
+          parseExpr [rawS|f "How are you?" "I am fine!"|]
           `shouldParse`
           Apply' (Apply' (Var' "f")
                          (Lit' $ String' "How are you?")

--- a/server-test/Hrafnar/ParserSpec.hs
+++ b/server-test/Hrafnar/ParserSpec.hs
@@ -54,35 +54,35 @@ spec = do
 
             parseExpr [rawS|'\'|]
             `shouldFailWith`
-            err 3 (ueof <> etok '\'') -- This error means no ending quote mark.
+            err 3 (ueof <> etok [rawC|'|]) -- This error means no ending quote mark.
 
           it "parse a single quote" $
 
             parseExpr [rawS|'''|]
             `shouldParse`
-            Lit' (Char' '\'')
+            Lit' (Char' [rawC|'|])
 
           it "parse a double quote" $
 
             parseExpr [rawS|'"'|]
             `shouldParse`
-            Lit' (Char' '\"')
+            Lit' (Char' [rawC|"|])
 
           it "fail on a zero length character" $
 
             parseExpr [rawS|''|]
             `shouldFailWith`
-            err 2 (ueof <> etok '\'') -- This error means no ending quote mark.
+            err 2 (ueof <> etok [rawC|'|]) -- This error means no ending quote mark.
             -- NOTE: This error depends on whether HML tries to parse a single
             -- quote without escaping or not.
             -- If it did not, the error might be:
-            --     err 1 (utok '\'')
+            --     err 1 (utok [rawC|'|])
 
           it "fail on a multiple length character" $
 
             parseExpr [rawS|'ab'|]
             `shouldFailWith`
-            err 2 (utok 'b' <> etok '\'')
+            err 2 (utok 'b' <> etok [rawC|'|])
 
         context "with escaping" $ do
 

--- a/server-test/Hrafnar/ParserSpec.hs
+++ b/server-test/Hrafnar/ParserSpec.hs
@@ -110,7 +110,7 @@ spec = do
             `shouldParse`
             Lit' (Char' 'L')
 
-          it "parse a ascii control code abbreviation" $
+          it "parse an ascii control code abbreviation" $
 
             parseExpr [rawS|'\LF'|]
             `shouldParse`

--- a/util/Hrafnar/Util.hs
+++ b/util/Hrafnar/Util.hs
@@ -21,6 +21,9 @@ rawS = genQQ id
 
 -- raw char
 rawC :: QuasiQuoter
-rawC = genQQ head
--- HACK: `head` does not raise an error when a given string is more than
--- 1 charcter. It smells bad.
+rawC = genQQ toChar
+  where
+    toChar :: String -> Char
+    toChar [] = error "no character"
+    toChar [x] = x
+    toChar (_:_) = error "multiple characters"

--- a/util/Hrafnar/Util.hs
+++ b/util/Hrafnar/Util.hs
@@ -1,0 +1,26 @@
+module Hrafnar.Util
+  ( rawS
+  , rawC
+  ) where
+
+import           Language.Haskell.TH.Quote
+import qualified Language.Haskell.TH.Syntax as S
+
+genQQ :: S.Lift a => (String -> a) -> QuasiQuoter
+genQQ parseFunc =
+  QuasiQuoter
+    { quoteExp = S.lift . parseFunc
+    , quotePat = undefined
+    , quoteType = undefined
+    , quoteDec = undefined
+    }
+
+-- raw string
+rawS :: QuasiQuoter
+rawS = genQQ id
+
+-- raw char
+rawC :: QuasiQuoter
+rawC = genQQ head
+-- HACK: `head` does not raise an error when a given string is more than
+-- 1 charcter. It smells bad.


### PR DESCRIPTION
resolve #56 

TODO:

*   tests about `Util` module
*   here-docs for multiple line strings with smart indentations, like below

```hs
[multiline|// This is a JavaScript snippet
          |function foo() {
          |  return 'hello';
          |}
|]
```