### PR TITLE
Test for QuasiQuotes

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -87,6 +87,7 @@ default-extensions:
 - RecordWildCards
 - PolyKinds
 - ScopedTypeVariables
+- TemplateHaskell
 - TupleSections
 - TypeApplications
 - TypeFamilies
@@ -137,3 +138,11 @@ tests:
     - smallcheck-series
     - case-insensitive
     - wai-extra
+
+  util-test:
+    main:                Main.hs
+    source-dirs:         util-test
+    dependencies:
+      - hrafnar-util
+      - hspec
+      - th-test-utils

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,5 +14,6 @@ extra-deps:
 - req-2.0.1@sha256:a677b3cb7534e101d2af86e6d12ae94cec57067314763fd2c89a6bc51a6d2fab
 - retry-0.8.0.0@sha256:319a0586876d43622bfe9406fad067adf0b4e591d125ad960bcc405237cc28f5
 - smallcheck-series-0.6.1
+- th-test-utils-1.0.1@sha256:1803d3556474c984cbd195d80b313461a9f170f189eb92da3b1283e6022438b2,2083
 # ghc-options:
   # hrafnar: -Wall -Werror

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -74,6 +74,13 @@ packages:
       sha256: 2627ec6bf905f0cade652855e42a1f6e4eab4daafcd6bb693e9749277a832dbd
   original:
     hackage: smallcheck-series-0.6.1
+- completed:
+    hackage: th-test-utils-1.0.1@sha256:1803d3556474c984cbd195d80b313461a9f170f189eb92da3b1283e6022438b2,2083
+    pantry-tree:
+      size: 393
+      sha256: 40a0e535a0d6cfd521749852ff0d4c3add83e36976be0cc3f8facf27a261afd9
+  original:
+    hackage: th-test-utils-1.0.1@sha256:1803d3556474c984cbd195d80b313461a9f170f189eb92da3b1283e6022438b2,2083
 snapshots:
 - completed:
     size: 498186

--- a/util-test/Hrafnar/UtilSpec.hs
+++ b/util-test/Hrafnar/UtilSpec.hs
@@ -1,0 +1,51 @@
+module Hrafnar.UtilSpec where
+
+import           Hrafnar.Util
+
+import           Test.Hspec
+import           Language.Haskell.TH.TestUtils
+
+import           Language.Haskell.TH.Quote
+
+spec :: Spec
+spec = do
+
+  describe "rawC" $ do
+
+    it "behave like single quotes" $
+
+      [rawC|a|] `shouldBe` 'a'
+
+    it "can interpret a single quote without any escaping" $
+
+      [rawC|'|] `shouldBe` '\''
+
+    it "can interpret a back-slash without any escaping" $
+
+      [rawC|\|] `shouldBe` '\\'
+
+    it "fail when no character is given" $
+
+      $(tryQErr $ quoteExp rawC "")
+      `shouldBe`
+      Just "no character"
+
+    it "fail when multiple characters are given" $
+
+      $(tryQErr $ quoteExp rawC "ab")
+      `shouldBe`
+      Just "multiple characters"
+
+  describe "rawS" $ do
+
+    it "behave like double quotes" $
+
+      [rawS|abc|] `shouldBe` "abc"
+
+    it "can interpret a double quote without any escaping" $
+
+      [rawS|"|] `shouldBe` "\""
+
+    it "can interpret a back-slash without any escaping" $
+
+      [rawS|\|] `shouldBe` "\\"

--- a/util-test/Main.hs
+++ b/util-test/Main.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import qualified SpecUtil
+import           Test.Hspec.Runner
+
+main :: IO ()
+main =
+  hspecWith defaultConfig SpecUtil.spec

--- a/util-test/SpecUtil.hs
+++ b/util-test/SpecUtil.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=SpecUtil #-}

--- a/util/Hrafnar/Util.hs
+++ b/util/Hrafnar/Util.hs
@@ -3,27 +3,32 @@ module Hrafnar.Util
   , rawC
   ) where
 
+import           Language.Haskell.TH
 import           Language.Haskell.TH.Quote
 import qualified Language.Haskell.TH.Syntax as S
 
-genQQ :: S.Lift a => (String -> a) -> QuasiQuoter
-genQQ parseFunc =
+genQQ :: S.Lift a => (String -> Either String a) -> QuasiQuoter
+genQQ parser =
   QuasiQuoter
-    { quoteExp = S.lift . parseFunc
+    { quoteExp = quoteExp . parser
     , quotePat = undefined
     , quoteType = undefined
     , quoteDec = undefined
     }
+  where
+    quoteExp :: S.Lift a => Either String a -> Q Exp
+    quoteExp (Left x) = fail x
+    quoteExp (Right x) = S.lift x
 
 -- raw string
 rawS :: QuasiQuoter
-rawS = genQQ id
+rawS = genQQ Right
 
 -- raw char
 rawC :: QuasiQuoter
 rawC = genQQ toChar
   where
-    toChar :: String -> Char
-    toChar [] = error "no character"
-    toChar [x] = x
-    toChar (_:_) = error "multiple characters"
+    toChar :: String -> Either String Char
+    toChar [] = Left "no character"
+    toChar [x] = Right x
+    toChar (_:_) = Left "multiple characters"


### PR DESCRIPTION
fix #59 

## The purpose of refactoring

My purpose of 2c889cf is... 

*   to use a more natural way.
    *   > To abort the computation, use `fail`.
         <https://hackage.haskell.org/package/template-haskell-2.15.0.0/docs/Language-Haskell-TH.html#g:2>
*   to make error states easier to handle.

## Side effect of the refactoring

By 2c889cf , compile-time error messages are changed.
I think but this change is good. They get more simple.

Before:

```sh
/Users/ikngtty/Projects/src/github.com/realglobe-Inc/hrafnar/server-test/Hrafnar/ParserSpec.hs:69:25: error:
    • Exception when trying to run compile-time code:
        multiple characters
CallStack (from HasCallStack):
  error, called at util/Hrafnar/Util.hs:29:20 in hrafnar-0.1.0.0-Jqfmt167IwoGCyqBIvYRaG-hrafnar-util:Hrafnar.Util
      Code: Language.Haskell.TH.Quote.quoteExp rawC "ab"
    • In the quasi-quotation: [rawC|ab|]
   |                 
69 |             Lit' (Char' [rawC|ab|])
   |                         ^^^^^^^^^^
```

After:

```sh
/Users/ikngtty/Projects/src/github.com/realglobe-Inc/hrafnar/server-test/Hrafnar/ParserSpec.hs:69:31: error:
    • multiple characters
    • In the quasi-quotation: [rawC|ab|]
   |        
69 |             Lit' (Char' [rawC|ab|])
   |                               ^^^^
```